### PR TITLE
Added SetIfAbsent() operation

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -45,6 +45,19 @@ func (m *ConcurrentMap) Set(key string, value interface{}) {
 	shard.items[key] = value
 }
 
+// Sets the given value under the specified key if no value was associated with it.
+func (m *ConcurrentMap) SetIfAbsent(key string, value interface{}) bool {
+	// Get map shard.
+	shard := m.GetShard(key)
+	shard.Lock()
+	defer shard.Unlock()
+	_, ok := shard.items[key]
+	if !ok {
+		shard.items[key] = value
+	}
+	return !ok
+}
+
 // Retrieves an element from map under given key.
 func (m ConcurrentMap) Get(key string) (interface{}, bool) {
 	// Get shard

--- a/concurrent_map_test.go
+++ b/concurrent_map_test.go
@@ -35,6 +35,17 @@ func TestInsert(t *testing.T) {
 	}
 }
 
+func TestInsertAbsent(t *testing.T) {
+	m := New()
+	elephant := Animal{"elephant"}
+	monkey := Animal{"monkey"}
+
+	m.SetIfAbsent("elephant", elephant)
+	if ok := m.SetIfAbsent("elephant", monkey); ok {
+		t.Error("map set a new value even the entry is already present")
+	}
+}
+
 func TestGet(t *testing.T) {
 	m := New()
 


### PR DESCRIPTION
This adds a `SetIfAbsent()` operation, an atomic operation (in the sense that the check and potential set are performed while the shard is locked) that associates a value with a key only if that key does not exist in the map.

This also includes a test to verify that the functionality is working as expected.