### PR TITLE
Fixes #12 - simple benchmarks

### DIFF
--- a/concurrent_map_bench_test.go
+++ b/concurrent_map_bench_test.go
@@ -1,0 +1,160 @@
+package cmap
+
+import "testing"
+import "strconv"
+
+func BenchmarkStrconv(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		strconv.Itoa(i)
+	}
+}
+
+func BenchmarkSingleInsertAbsent(b *testing.B) {
+	m := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Set(strconv.Itoa(i), "value")
+	}
+}
+
+func BenchmarkSingleInsertPresent(b *testing.B) {
+	m := New()
+	m.Set("key", "value")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Set("key", "value")
+	}
+}
+
+func benchmarkMultiInsertDifferent(b *testing.B) {
+	m := New()
+	finished := make(chan struct{}, b.N)
+	_, set := GetSet(m, finished)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set(strconv.Itoa(i), "value")
+	}
+	for i := 0; i < b.N; i++ {
+		<-finished
+	}
+}
+
+func BenchmarkMultiInsertDifferent_1_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiInsertDifferent, b, 1)
+}
+func BenchmarkMultiInsertDifferent_16_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiInsertDifferent, b, 16)
+}
+func BenchmarkMultiInsertDifferent_32_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiInsertDifferent, b, 32)
+}
+func BenchmarkMultiInsertDifferent_256_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetDifferent, b, 256)
+}
+
+func BenchmarkMultiInsertSame(b *testing.B) {
+	m := New()
+	finished := make(chan struct{}, b.N)
+	_, set := GetSet(m, finished)
+	m.Set("key", "value")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set("key", "value")
+	}
+	for i := 0; i < b.N; i++ {
+		<-finished
+	}
+}
+
+func BenchmarkMultiGetSame(b *testing.B) {
+	m := New()
+	finished := make(chan struct{}, b.N)
+	get, _ := GetSet(m, finished)
+	m.Set("key", "value")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		get("key", "value")
+	}
+	for i := 0; i < b.N; i++ {
+		<-finished
+	}
+}
+
+func benchmarkMultiGetSetDifferent(b *testing.B) {
+	m := New()
+	finished := make(chan struct{}, 2*b.N)
+	get, set := GetSet(m, finished)
+	m.Set("-1", "value")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set(strconv.Itoa(i-1), "value")
+		get(strconv.Itoa(i), "value")
+	}
+	for i := 0; i < 2*b.N; i++ {
+		<-finished
+	}
+}
+
+func BenchmarkMultiGetSetDifferent_1_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetDifferent, b, 1)
+}
+func BenchmarkMultiGetSetDifferent_16_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetDifferent, b, 16)
+}
+func BenchmarkMultiGetSetDifferent_32_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetDifferent, b, 32)
+}
+func BenchmarkMultiGetSetDifferent_256_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetDifferent, b, 256)
+}
+
+func benchmarkMultiGetSetBlock(b *testing.B) {
+	m := New()
+	finished := make(chan struct{}, 2*b.N)
+	get, set := GetSet(m, finished)
+	for i := 0; i < b.N; i++ {
+		m.Set(strconv.Itoa(i%100), "value")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		set(strconv.Itoa(i%100), "value")
+		get(strconv.Itoa(i%100), "value")
+	}
+	for i := 0; i < 2*b.N; i++ {
+		<-finished
+	}
+}
+
+func BenchmarkMultiGetSetBlock_1_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetBlock, b, 1)
+}
+func BenchmarkMultiGetSetBlock_16_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetBlock, b, 16)
+}
+func BenchmarkMultiGetSetBlock_32_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetBlock, b, 32)
+}
+func BenchmarkMultiGetSetBlock_256_Shard(b *testing.B) {
+	runWithShards(benchmarkMultiGetSetBlock, b, 256)
+}
+
+func GetSet(m ConcurrentMap, finished chan struct{}) (set func(key, value string), get func(key, value string)) {
+	return func(key, value string) {
+			for i := 0; i < 10; i++ {
+				m.Get(key)
+			}
+			finished <- struct{}{}
+		}, func(key, value string) {
+			for i := 0; i < 10; i++ {
+				m.Set(key, value)
+			}
+			finished <- struct{}{}
+		}
+}
+
+func runWithShards(bench func(b *testing.B), b *testing.B, shardsCount int) {
+	oldShardsCount := SHARD_COUNT
+	SHARD_COUNT = shardsCount
+	bench(b)
+	SHARD_COUNT = oldShardsCount
+}


### PR DESCRIPTION
Here are my results

```
~ go version
go version go1.6rc2 linux/amd64
~ go test -bench=. -benchtime 10s
PASS
BenchmarkStrconv-24                       	100000000	       123 ns/op
BenchmarkSingleInsertAbsent-24            	10000000	      1735 ns/op
BenchmarkSingleInsertPresent-24           	30000000	       480 ns/op
BenchmarkMultiInsertDifferent_1_Shard-24  	 2000000	      6780 ns/op
BenchmarkMultiInsertDifferent_16_Shard-24 	 2000000	      6744 ns/op
BenchmarkMultiInsertDifferent_32_Shard-24 	 2000000	      6485 ns/op
BenchmarkMultiInsertDifferent_256_Shard-24	 2000000	      9643 ns/op
BenchmarkMultiInsertSame-24               	 3000000	      4893 ns/op
BenchmarkMultiGetSame-24                  	 5000000	      3219 ns/op
BenchmarkMultiGetSetDifferent_1_Shard-24  	 1000000	     10121 ns/op
BenchmarkMultiGetSetDifferent_16_Shard-24 	 1000000	     10248 ns/op
BenchmarkMultiGetSetDifferent_32_Shard-24 	 2000000	     10036 ns/op
BenchmarkMultiGetSetDifferent_256_Shard-24	 2000000	      9478 ns/op
BenchmarkMultiGetSetBlock_1_Shard-24      	 2000000	      8743 ns/op
BenchmarkMultiGetSetBlock_16_Shard-24     	 2000000	      8936 ns/op
BenchmarkMultiGetSetBlock_32_Shard-24     	 2000000	      8774 ns/op
BenchmarkMultiGetSetBlock_256_Shard-24    	 2000000	      8646 ns/op
ok  	_/home/samba/janiszewskit/concurrent-map	367.962s

```