### PR TITLE
change defer unlock to immediatly unlock to avoid delay call which can speed up all func call

### DIFF
--- a/concurrent_map.go
+++ b/concurrent_map.go
@@ -41,8 +41,8 @@ func (m *ConcurrentMap) Set(key string, value interface{}) {
 	// Get map shard.
 	shard := m.GetShard(key)
 	shard.Lock()
-	defer shard.Unlock()
 	shard.items[key] = value
+	shard.Unlock()
 }
 
 // Sets the given value under the specified key if no value was associated with it.
@@ -50,11 +50,11 @@ func (m *ConcurrentMap) SetIfAbsent(key string, value interface{}) bool {
 	// Get map shard.
 	shard := m.GetShard(key)
 	shard.Lock()
-	defer shard.Unlock()
 	_, ok := shard.items[key]
 	if !ok {
 		shard.items[key] = value
 	}
+	shard.Unlock()
 	return !ok
 }
 
@@ -63,10 +63,9 @@ func (m ConcurrentMap) Get(key string) (interface{}, bool) {
 	// Get shard
 	shard := m.GetShard(key)
 	shard.RLock()
-	defer shard.RUnlock()
-
 	// Get item from shard.
 	val, ok := shard.items[key]
+	shard.RUnlock()
 	return val, ok
 }
 
@@ -87,10 +86,9 @@ func (m *ConcurrentMap) Has(key string) bool {
 	// Get shard
 	shard := m.GetShard(key)
 	shard.RLock()
-	defer shard.RUnlock()
-
 	// See if element is within shard.
 	_, ok := shard.items[key]
+	shard.RUnlock()
 	return ok
 }
 
@@ -99,8 +97,8 @@ func (m *ConcurrentMap) Remove(key string) {
 	// Try to get shard.
 	shard := m.GetShard(key)
 	shard.Lock()
-	defer shard.Unlock()
 	delete(shard.items, key)
+	shard.Unlock()
 }
 
 // Checks if map is empty.


### PR DESCRIPTION
benchmark while using defer:

>
sillydong:concurrent-map chenzhidong$ go test -v -run="-" -bench . -benchmem
PASS
BenchmarkStrconv-4                       	20000000	        75.5 ns/op	       7 B/op	       1 allocs/op
BenchmarkSingleInsertAbsent-4            	 1000000	      1665 ns/op	     199 B/op	       4 allocs/op
BenchmarkSingleInsertPresent-4           	 5000000	       379 ns/op	      32 B/op	       3 allocs/op
BenchmarkMultiInsertDifferent_1_Shard-4  	  300000	      5181 ns/op	     462 B/op	      31 allocs/op
BenchmarkMultiInsertDifferent_16_Shard-4 	  300000	      5034 ns/op	     462 B/op	      31 allocs/op
BenchmarkMultiInsertDifferent_32_Shard-4 	  300000	      5175 ns/op	     463 B/op	      31 allocs/op
BenchmarkMultiInsertDifferent_256_Shard-4	  200000	      8076 ns/op	     639 B/op	      52 allocs/op
BenchmarkMultiInsertSame-4               	  300000	      3774 ns/op	     320 B/op	      30 allocs/op
BenchmarkMultiGetSame-4                  	 1000000	      2489 ns/op	     160 B/op	      20 allocs/op
BenchmarkMultiGetSetDifferent_1_Shard-4  	  200000	      9674 ns/op	     601 B/op	      52 allocs/op
BenchmarkMultiGetSetDifferent_16_Shard-4 	  200000	      8347 ns/op	     602 B/op	      52 allocs/op
BenchmarkMultiGetSetDifferent_32_Shard-4 	  200000	     11658 ns/op	     603 B/op	      52 allocs/op
BenchmarkMultiGetSetDifferent_256_Shard-4	  200000	      8348 ns/op	     639 B/op	      52 allocs/op
BenchmarkMultiGetSetBlock_1_Shard-4      	  200000	      6966 ns/op	     480 B/op	      52 allocs/op
BenchmarkMultiGetSetBlock_16_Shard-4     	  200000	      6803 ns/op	     480 B/op	      52 allocs/op
BenchmarkMultiGetSetBlock_32_Shard-4     	  200000	      6592 ns/op	     480 B/op	      52 allocs/op
BenchmarkMultiGetSetBlock_256_Shard-4    	  200000	      6640 ns/op	     480 B/op	      52 allocs/op
ok  	github.com/sillydong/concurrent-map	30.867s

benchmark without defer:

>
sillydong:concurrent-map chenzhidong$ go test -v -run="-" -bench . -benchmem
PASS
BenchmarkStrconv-4                       	20000000	        73.6 ns/op	       7 B/op	       1 allocs/op
BenchmarkSingleInsertAbsent-4            	 1000000	      1270 ns/op	     199 B/op	       4 allocs/op
BenchmarkSingleInsertPresent-4           	 5000000	       245 ns/op	      32 B/op	       3 allocs/op
BenchmarkMultiInsertDifferent_1_Shard-4  	  500000	      4252 ns/op	     487 B/op	      31 allocs/op
BenchmarkMultiInsertDifferent_16_Shard-4 	  500000	      4214 ns/op	     487 B/op	      31 allocs/op
BenchmarkMultiInsertDifferent_32_Shard-4 	  500000	      4048 ns/op	     488 B/op	      31 allocs/op
BenchmarkMultiInsertDifferent_256_Shard-4	  300000	      5700 ns/op	     639 B/op	      52 allocs/op
BenchmarkMultiInsertSame-4               	  500000	      2524 ns/op	     320 B/op	      30 allocs/op
BenchmarkMultiGetSame-4                  	 1000000	      1375 ns/op	     160 B/op	      20 allocs/op
BenchmarkMultiGetSetDifferent_1_Shard-4  	  300000	      5764 ns/op	     630 B/op	      52 allocs/op
BenchmarkMultiGetSetDifferent_16_Shard-4 	  300000	      5596 ns/op	     630 B/op	      52 allocs/op
BenchmarkMultiGetSetDifferent_32_Shard-4 	  300000	      5793 ns/op	     631 B/op	      52 allocs/op
BenchmarkMultiGetSetDifferent_256_Shard-4	  300000	      5638 ns/op	     639 B/op	      52 allocs/op
BenchmarkMultiGetSetBlock_1_Shard-4      	  300000	      4337 ns/op	     480 B/op	      52 allocs/op
BenchmarkMultiGetSetBlock_16_Shard-4     	  300000	      4343 ns/op	     480 B/op	      52 allocs/op
BenchmarkMultiGetSetBlock_32_Shard-4     	  300000	      4173 ns/op	     480 B/op	      52 allocs/op
BenchmarkMultiGetSetBlock_256_Shard-4    	  300000	      4116 ns/op	     480 B/op	      52 allocs/op
ok  	github.com/sillydong/concurrent-map	28.140s